### PR TITLE
Try to optimize len() implementation 

### DIFF
--- a/fixtures/sample.json
+++ b/fixtures/sample.json
@@ -59,5 +59,6 @@
     "upper_fence": null,
     "sample_key": "0003"
   },
-  "height": 3
+  "height": 3,
+  "len": 3
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,8 @@ enum TreeNode {
 #[derive(Deserialize, Debug)]
 struct Tree {
     root: TreeNode,
-    height: usize
+    height: usize,
+    len: usize
 }
 
 fn translate_node(tree_node: TreeNode) -> Atomic<HybridLatch<DefaultNode<String, u64>>> {
@@ -96,6 +97,7 @@ pub fn sample_tree<P: AsRef<std::path::Path>>(path: P) -> BPlusTree<String, u64>
     let translated = translate_node(tree.root);
     BPlusTree {
         root: HybridLatch::new(translated),
-        height: AtomicUsize::new(tree.height)
+        height: AtomicUsize::new(tree.height),
+        len: AtomicUsize::new(tree.len)
     }
 }


### PR DESCRIPTION
I found that in the current `len()` impl of type `GenericBPlusTree` in `lib.rs` traverse and iterate through the structure, I wonder whether it is necessary: I don't fully understand the impl, but I think the insertion and removal methods of `GenericBPlusTree` is transactional, so I personally thought that if we introduce and maintain a len field, that keeps track of the active element, then the iteration can be avoided in `len()`, i.e. the time complexity is O(1).
I tried to implement it with AtomicUsize and the corresponding memory order. But I didn't do full integrated tests; rather, I only did unit tests.
Since the preliminary unit test in a multithreading environment is passed, I thought maybe that optimization is feasible? Or I didn't understand the design?

